### PR TITLE
EC2를 배포한다.

### DIFF
--- a/env/dev/ec2/.terraform.lock.hcl
+++ b/env/dev/ec2/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "6.4.0"
+  constraints = ">= 6.0.0"
+  hashes = [
+    "h1:2gKOcsPikRhuukFKc7zvsbNRoQt/P99CxCS4pLlo5Xk=",
+    "zh:05946a97a2d98d3a77f2dfb1133b39d61b1166f717f051a8aa44eca22a7446b0",
+    "zh:07278697234332b254e990fff84fa5608aabdb256a0dbed05dfe336905d385a1",
+    "zh:1b1ad46267c84fa474618048a9ad94a634cf5d0e5ec3c8e56a854638129ae4da",
+    "zh:1ff04914571b1dfa485358badbc81306e34d8ebec4aa1f96b8c1c3d2eb0e4d4a",
+    "zh:43d7fb899186ca1b355af908d0904ea94a1e06de220de0b9752f06465386f66f",
+    "zh:49ce34c359d5b05ba684482dace5e9c418f3beabcc2b0d129b21687cb7673cab",
+    "zh:4bbad3a23dd704b1548da40e9c81befb617a0c02e5a9776ef0eff5ef920881c5",
+    "zh:680aa4bd542c7a847f7df91cd1fa33fe8d19914aa80a2570ea6c82ab2d1f5740",
+    "zh:792a74fe4d6b501571c582c25067f7f4dbdce2305d559d09981e7f99025c98ef",
+    "zh:7c06b331b6a6f160d2d64245b9aee32922a9cb9947b7a9ad8c0ec93a702ecb1b",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9f40add95d4f3e1c62df46bf37e13c30023d97eda47d4940904792f3b1a1827e",
+    "zh:b763c7c1bf5d8077d6499fd270cad249a712dd9522c6a6e4de49b278280806c5",
+    "zh:db69df59bef6f9d8bcb164414b4efa52c0c531c346d6b8b232917afa9b1c4a96",
+    "zh:dd9f98f64530386b8faaf9c55ec4b08e58725788c38683272a34684d82f866f7",
+  ]
+}

--- a/env/dev/ec2/terragrunt.hcl
+++ b/env/dev/ec2/terragrunt.hcl
@@ -1,0 +1,23 @@
+include {
+  path = find_in_parent_folders()
+}
+
+terraform {
+  source = "${get_parent_terragrunt_dir()}/../../modules/ec2"
+}
+
+dependency "vpc" {
+  config_path = "../vpc"
+  mock_outputs = {
+    vpc_id = "mock-vpc"
+    public_subnets = ["mock-public-subnet-1", "mock-public-subnet-2"]
+    private_subnets = ["mock-private-subnet-1", "mock-private-subnet-2"]
+  }
+}
+
+inputs = {
+  name          = "gotchai-dev-container-1"
+  ami           = "ami-0662f4965dfc70aca"
+  instance_type = "t2.micro"
+  subnet_id     = dependency.vpc.outputs.public_subnets[0]
+}

--- a/env/dev/terragrunt.hcl
+++ b/env/dev/terragrunt.hcl
@@ -1,0 +1,34 @@
+generate "provider" {
+  path      = "provider.tf"
+  if_exists = "overwrite_terragrunt"
+  contents  = <<EOF
+    terraform {
+      required_providers {
+        aws = {
+          source  = "hashicorp/aws"
+          version = "~> 6.0"
+        }
+      }
+    }
+  EOF
+}
+
+remote_state {
+  backend = "s3"
+  generate = {
+    path      = "backend.tf"
+    if_exists = "overwrite_terragrunt"
+  }
+  config = {
+    bucket = "gotchai-dev-state"
+
+    key            = "${path_relative_to_include()}/terraform.tfstate"
+    region         = "ap-northeast-2"
+    encrypt        = true
+    dynamodb_table = "gotchai-dev-lock"
+  }
+}
+
+inputs = {
+  env = "dev"
+}

--- a/env/dev/vpc/.terraform.lock.hcl
+++ b/env/dev/vpc/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "6.4.0"
+  constraints = ">= 6.0.0"
+  hashes = [
+    "h1:2gKOcsPikRhuukFKc7zvsbNRoQt/P99CxCS4pLlo5Xk=",
+    "zh:05946a97a2d98d3a77f2dfb1133b39d61b1166f717f051a8aa44eca22a7446b0",
+    "zh:07278697234332b254e990fff84fa5608aabdb256a0dbed05dfe336905d385a1",
+    "zh:1b1ad46267c84fa474618048a9ad94a634cf5d0e5ec3c8e56a854638129ae4da",
+    "zh:1ff04914571b1dfa485358badbc81306e34d8ebec4aa1f96b8c1c3d2eb0e4d4a",
+    "zh:43d7fb899186ca1b355af908d0904ea94a1e06de220de0b9752f06465386f66f",
+    "zh:49ce34c359d5b05ba684482dace5e9c418f3beabcc2b0d129b21687cb7673cab",
+    "zh:4bbad3a23dd704b1548da40e9c81befb617a0c02e5a9776ef0eff5ef920881c5",
+    "zh:680aa4bd542c7a847f7df91cd1fa33fe8d19914aa80a2570ea6c82ab2d1f5740",
+    "zh:792a74fe4d6b501571c582c25067f7f4dbdce2305d559d09981e7f99025c98ef",
+    "zh:7c06b331b6a6f160d2d64245b9aee32922a9cb9947b7a9ad8c0ec93a702ecb1b",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9f40add95d4f3e1c62df46bf37e13c30023d97eda47d4940904792f3b1a1827e",
+    "zh:b763c7c1bf5d8077d6499fd270cad249a712dd9522c6a6e4de49b278280806c5",
+    "zh:db69df59bef6f9d8bcb164414b4efa52c0c531c346d6b8b232917afa9b1c4a96",
+    "zh:dd9f98f64530386b8faaf9c55ec4b08e58725788c38683272a34684d82f866f7",
+  ]
+}

--- a/env/dev/vpc/terragrunt.hcl
+++ b/env/dev/vpc/terragrunt.hcl
@@ -1,0 +1,18 @@
+include {
+  path = find_in_parent_folders()
+}
+
+terraform {
+  source = "${get_parent_terragrunt_dir()}/../../modules/vpc"
+}
+
+inputs = {
+  name = "gotchai-dev"
+  cidr = "192.168.0.0/16"
+  azs = [
+    "ap-northeast-2a",
+    "ap-northeast-2b"
+  ]
+  subnet_count       = 2
+  enable_nat_gateway = false
+}

--- a/modules/ec2/.terraform.lock.hcl
+++ b/modules/ec2/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "6.4.0"
+  constraints = ">= 6.0.0"
+  hashes = [
+    "h1:2gKOcsPikRhuukFKc7zvsbNRoQt/P99CxCS4pLlo5Xk=",
+    "zh:05946a97a2d98d3a77f2dfb1133b39d61b1166f717f051a8aa44eca22a7446b0",
+    "zh:07278697234332b254e990fff84fa5608aabdb256a0dbed05dfe336905d385a1",
+    "zh:1b1ad46267c84fa474618048a9ad94a634cf5d0e5ec3c8e56a854638129ae4da",
+    "zh:1ff04914571b1dfa485358badbc81306e34d8ebec4aa1f96b8c1c3d2eb0e4d4a",
+    "zh:43d7fb899186ca1b355af908d0904ea94a1e06de220de0b9752f06465386f66f",
+    "zh:49ce34c359d5b05ba684482dace5e9c418f3beabcc2b0d129b21687cb7673cab",
+    "zh:4bbad3a23dd704b1548da40e9c81befb617a0c02e5a9776ef0eff5ef920881c5",
+    "zh:680aa4bd542c7a847f7df91cd1fa33fe8d19914aa80a2570ea6c82ab2d1f5740",
+    "zh:792a74fe4d6b501571c582c25067f7f4dbdce2305d559d09981e7f99025c98ef",
+    "zh:7c06b331b6a6f160d2d64245b9aee32922a9cb9947b7a9ad8c0ec93a702ecb1b",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9f40add95d4f3e1c62df46bf37e13c30023d97eda47d4940904792f3b1a1827e",
+    "zh:b763c7c1bf5d8077d6499fd270cad249a712dd9522c6a6e4de49b278280806c5",
+    "zh:db69df59bef6f9d8bcb164414b4efa52c0c531c346d6b8b232917afa9b1c4a96",
+    "zh:dd9f98f64530386b8faaf9c55ec4b08e58725788c38683272a34684d82f866f7",
+  ]
+}

--- a/modules/ec2/main.tf
+++ b/modules/ec2/main.tf
@@ -1,0 +1,15 @@
+module "ec2_instance" {
+  source  = "terraform-aws-modules/ec2-instance/aws"
+  version = "6.0.2"
+
+  name          = var.name
+  ami           = var.ami
+  instance_type = var.instance_type
+  subnet_id     = var.subnet_id
+  count         = var.instance_count
+
+  tags = {
+    CreatedBy   = "Terraform"
+    Environment = var.env
+  }
+}

--- a/modules/ec2/variables.tf
+++ b/modules/ec2/variables.tf
@@ -1,0 +1,24 @@
+variable "name" {
+  type = string
+}
+
+variable "ami" {
+  type = string
+}
+
+variable "instance_type" {
+  type = string
+}
+
+variable "subnet_id" {
+  type = string
+}
+
+variable "instance_count" {
+  type    = number
+  default = 1
+}
+
+variable "env" {
+  type = string
+}

--- a/modules/vpc/.terraform.lock.hcl
+++ b/modules/vpc/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "6.4.0"
+  constraints = ">= 6.0.0"
+  hashes = [
+    "h1:2gKOcsPikRhuukFKc7zvsbNRoQt/P99CxCS4pLlo5Xk=",
+    "zh:05946a97a2d98d3a77f2dfb1133b39d61b1166f717f051a8aa44eca22a7446b0",
+    "zh:07278697234332b254e990fff84fa5608aabdb256a0dbed05dfe336905d385a1",
+    "zh:1b1ad46267c84fa474618048a9ad94a634cf5d0e5ec3c8e56a854638129ae4da",
+    "zh:1ff04914571b1dfa485358badbc81306e34d8ebec4aa1f96b8c1c3d2eb0e4d4a",
+    "zh:43d7fb899186ca1b355af908d0904ea94a1e06de220de0b9752f06465386f66f",
+    "zh:49ce34c359d5b05ba684482dace5e9c418f3beabcc2b0d129b21687cb7673cab",
+    "zh:4bbad3a23dd704b1548da40e9c81befb617a0c02e5a9776ef0eff5ef920881c5",
+    "zh:680aa4bd542c7a847f7df91cd1fa33fe8d19914aa80a2570ea6c82ab2d1f5740",
+    "zh:792a74fe4d6b501571c582c25067f7f4dbdce2305d559d09981e7f99025c98ef",
+    "zh:7c06b331b6a6f160d2d64245b9aee32922a9cb9947b7a9ad8c0ec93a702ecb1b",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9f40add95d4f3e1c62df46bf37e13c30023d97eda47d4940904792f3b1a1827e",
+    "zh:b763c7c1bf5d8077d6499fd270cad249a712dd9522c6a6e4de49b278280806c5",
+    "zh:db69df59bef6f9d8bcb164414b4efa52c0c531c346d6b8b232917afa9b1c4a96",
+    "zh:dd9f98f64530386b8faaf9c55ec4b08e58725788c38683272a34684d82f866f7",
+  ]
+}

--- a/modules/vpc/main.tf
+++ b/modules/vpc/main.tf
@@ -1,0 +1,15 @@
+module "vpc" {
+  source  = "terraform-aws-modules/vpc/aws"
+  version = "6.0.1"
+
+  name               = var.name
+  cidr               = var.cidr
+  azs                = var.azs
+  public_subnets     = [for i in range(var.subnet_count / 2) : cidrsubnet(var.cidr, log(var.subnet_count, 2), i)]
+  private_subnets    = [for i in range(var.subnet_count / 2) : cidrsubnet(var.cidr, log(var.subnet_count, 2), i + (var.subnet_count / 2))]
+  enable_nat_gateway = var.enable_nat_gateway
+  tags = {
+    CreatedBy   = "Terraform"
+    Environment = var.env
+  }
+}

--- a/modules/vpc/outputs.tf
+++ b/modules/vpc/outputs.tf
@@ -1,0 +1,11 @@
+output "vpc_id" {
+  value = module.vpc.vpc_id
+}
+
+output "public_subnets" {
+  value = module.vpc.public_subnets
+}
+
+output "private_subnets" {
+  value = module.vpc.private_subnets
+}

--- a/modules/vpc/variables.tf
+++ b/modules/vpc/variables.tf
@@ -1,0 +1,28 @@
+variable "name" {
+  type = string
+}
+
+variable "cidr" {
+  type = string
+}
+
+variable "azs" {
+  type = list(string)
+}
+
+variable "subnet_count" {
+  type = number
+
+  validation {
+    condition     = log(var.subnet_count, 2) % 1 == 0
+    error_message = "subnet_count must be a power of 2."
+  }
+}
+
+variable "enable_nat_gateway" {
+  type = bool
+}
+
+variable "env" {
+  type = string
+}


### PR DESCRIPTION
## 관련 이슈
- close #1

## 작업 내용
- VPC와 EC2 배포를 위한 설정 파일 추가

## 참고
- VPC는 2n(짝수)개의 `subnet_count`를 받아 각각 n개씩 퍼블릭 및 프라이빗 서브넷을 구성하도록 했습니다.
- 현재는 로컬에서 Terraform을 통해 인프라 프로비저닝을 수행하고, 추후 GitHub Actions를 통해 이를 자동화하는 GItOps를 구현할 예정입니다.
