### PR TITLE
GitHub Actions에 ECR 관련 권한을 부여한다.

### DIFF
--- a/env/dev/github-actions/iam/terragrunt.hcl
+++ b/env/dev/github-actions/iam/terragrunt.hcl
@@ -8,5 +8,8 @@ terraform {
 
 inputs = {
   name = "github-actions"
-  policy_arns = ["arn:aws:iam::aws:policy/AmazonS3FullAccess"]
+  policy_arns = [
+    "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryPullOnly",
+    "arn:aws:iam::aws:policy/AmazonS3FullAccess"
+  ]
 }


### PR DESCRIPTION
## 관련 이슈
- close #5

## 작업 내용
- GitHub Actions가 사용하는 IAM User에 `AmazonEC2ContainerRegistryPullOnly` 권한 부여

## 참고
- GitHub Actions의 워크플로우에서`aws ecr get-login-password`에 대한 권한이 거부되던 문제를 해결하는 PR입니다.
