### PR TITLE
ALB와 EC2 내의 Swagger를 연결한다.

### DIFF
--- a/env/dev/elb/alb/terragrunt.hcl
+++ b/env/dev/elb/alb/terragrunt.hcl
@@ -41,7 +41,7 @@ inputs = {
   subnet_ids         = dependency.vpc.outputs.public_subnet_ids
   security_group_ids = [dependency.security_group.outputs.id]
   listeners = {
-    server-http = {
+    http = {
       port     = 80
       protocol = "HTTP"
       redirect = {
@@ -50,13 +50,32 @@ inputs = {
         status_code = "HTTP_301"
       }
     }
-    server-https = {
+    https = {
       port            = 443
       protocol        = "HTTPS"
       certificate_arn = dependency.acm.outputs.arn
 
       forward = {
         target_group_key = "server"
+      }
+
+      rules = {
+        api-docs-host = {
+          priority = 100
+          actions = [
+            {
+              type             = "forward"
+              target_group_key = "swagger"
+            }
+          ]
+          conditions = [
+            {
+              host_header = {
+                values = ["api-docs.gotchai-ai.com"]
+              }
+            }
+          ]
+        }
       }
     }
   }
@@ -70,6 +89,19 @@ inputs = {
 
       health_check = {
         path     = "/ping"
+        port     = "traffic-port"
+        protocol = "HTTP"
+      }
+    }
+    swagger = {
+      name_prefix = "h1"
+      protocol    = "HTTP"
+      port        = 9090
+      target_type = "instance"
+      target_id   = dependency.ec2.outputs.instance_ids[0]
+
+      health_check = {
+        path     = "/"
         port     = "traffic-port"
         protocol = "HTTP"
       }

--- a/env/dev/elb/records/terragrunt.hcl
+++ b/env/dev/elb/records/terragrunt.hcl
@@ -31,6 +31,14 @@ inputs = {
         name    = dependency.alb.outputs.dns_name
         zone_id = dependency.alb.outputs.zone_id
       }
+    },
+    {
+      name = "api-docs"
+      type = "A"
+      alias = {
+        name    = dependency.alb.outputs.dns_name
+        zone_id = dependency.alb.outputs.zone_id
+      }
     }
   ]
 }

--- a/env/dev/server/ec2/terragrunt.hcl
+++ b/env/dev/server/ec2/terragrunt.hcl
@@ -35,6 +35,7 @@ inputs = {
   iam_instance_profile  = dependency.role.outputs.instance_profile_name
   is_public             = true
   user_data             = <<-EOF
+    #!/bin/bash
     sudo dnf install -y docker
     sudo systemctl enable --now docker
     sudo usermod -aG docker ec2-user

--- a/env/dev/server/security-group/terragrunt.hcl
+++ b/env/dev/server/security-group/terragrunt.hcl
@@ -25,6 +25,18 @@ inputs = {
       cidr_blocks = "0.0.0.0/0"
     },
     {
+      from_port   = 8080
+      to_port     = 8080
+      protocol    = "TCP"
+      cidr_blocks = "0.0.0.0/0"
+    },
+    {
+      from_port   = 9090
+      to_port     = 9090
+      protocol    = "TCP"
+      cidr_blocks = "0.0.0.0/0"
+    },
+    {
       from_port   = 6379
       to_port     = 6379
       protocol    = "TCP"


### PR DESCRIPTION
## 관련 이슈
- close #29

## 작업 내용
- ALB와 EC2 내의 Swagger 연결

## 설명
- 서브 도메인(`api-docs.gotchai-ai.com`) 기반으로 Swagger와 연결되도록 했습니다.
