### PR TITLE
RDS Password Rotation을 비활성화한다.

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -57,7 +57,7 @@ jobs:
           "embeds": [
             {
               "title": "**인프라 ${{ github.ref_name == 'prod' && '프로덕션' || '개발' }} 환경 배포 ${{ needs.deploy-infra.result == 'success' && '성공' || '실패' }}**",
-              "description": ${{ needs.deploy-infra.result == 'success' && 'AWS 인프라가 성공적으로 배포되었습니다.' || 'AWS 인프라 배포에 실패했습니다.' }},
+              "description": "${{ needs.deploy-infra.result == 'success' && 'AWS 인프라가 성공적으로 배포되었습니다.' || 'AWS 인프라 배포에 실패했습니다.' }}",
               "color": ${{ needs.deploy-infra.result == 'success' && 3066993 || 15158332 }},
               "fields": [
                 {

--- a/global/database/rds/terragrunt.hcl
+++ b/global/database/rds/terragrunt.hcl
@@ -21,15 +21,16 @@ dependency "security-group" {
 }
 
 inputs = {
-  name               = "gotchai-db"
-  engine             = "mysql"
-  engine_version     = "8.4.3"
-  instance_class     = "db.t3.micro"
-  username           = "gotchai"
-  db_name            = "gotchai"
-  allocated_storage  = 20
-  storage_type       = "gp2"
-  is_public          = true
-  subnet_ids         = dependency.vpc.outputs.public_subnet_ids
-  security_group_ids = [dependency.security-group.outputs.id]
+  name                 = "gotchai-db"
+  engine               = "mysql"
+  engine_version       = "8.4.3"
+  instance_class       = "db.t3.micro"
+  username             = "gotchai"
+  db_name              = "gotchai"
+  allocated_storage    = 20
+  storage_type         = "gp2"
+  is_public            = true
+  subnet_ids           = dependency.vpc.outputs.public_subnet_ids
+  security_group_ids   = [dependency.security-group.outputs.id]
+  is_password_rotation = false
 }

--- a/modules/rds/main.tf
+++ b/modules/rds/main.tf
@@ -18,6 +18,8 @@ module "rds" {
   subnet_ids             = var.subnet_ids
   vpc_security_group_ids = var.security_group_ids
   publicly_accessible    = var.is_public
+  manage_master_user_password_rotation = var.is_password_rotation
+  master_user_password_rotation_automatically_after_days = var.password_rotation_period
   deletion_protection    = true
 
   tags = {

--- a/modules/rds/variables.tf
+++ b/modules/rds/variables.tf
@@ -35,6 +35,16 @@ variable "security_group_ids" {
   default = []
 }
 
+variable "is_password_rotation" {
+  type = bool
+  default = true
+}
+
+variable "password_rotation_period" {
+  type = number
+  default = 7
+}
+
 variable "is_public" {
   type    = bool
   default = false


### PR DESCRIPTION
## 관련 이슈
- close #33

## 작업 내용
- RDS Password Rotation 비활성화

## 설명
- RDS에서 패스워드가 자꾸 변경되어 환경변수 관련 오류가 발생하던 문제를 해결하는 PR입니다.
- `manage_master_user_password_rotation`에 대한 아래 공식 문서 설명에 따르면 RDS 초기 생성 시에는 어떻게든 rotation 설정을 막을 방법이 없다네요. 그래서 한번 `true`로 배포하고 이후 `false`로 수정해서 rotation을 비활성화 했습니다 ㅋㅋ(좀 그지같음)
  - "There is not currently a way to disable this on initial creation even when set to false. Setting this value to false after previously having been set to true will disable automatic rotation."