### PR TITLE
ELB Target Group에 헬스 체크 적용

### DIFF
--- a/modules/elb/alb/.terraform.lock.hcl
+++ b/modules/elb/alb/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "6.9.0"
+  constraints = ">= 5.99.0"
+  hashes = [
+    "h1:tYd0S1e8xSwAM3NtDrvu2e80pV9fvLEWAjhtDR4JP5o=",
+    "zh:0121aeca90856ba37d03cff9eed40321cc3ae1c0f77bef3329e17212c48f884a",
+    "zh:4f09e73f948d4545358eed978bc41fd1a825c65b530a532bfaf9aaba93ac6e55",
+    "zh:58604213402b5dba8360367e09b3d3762736980c80a72d6297be7cb71fe8dc8d",
+    "zh:5aa9fe54fc9aba0780cae11becfce698e5093ee002066590599277d5aa71e59e",
+    "zh:7e8546575a80d54b8db7edb53574c2d1f04afbdbafc599d0eb78da9e74e917f7",
+    "zh:846ce59c9f7ec3c92b33fe3a0d98386420bcbb971260da9ff869b219a1125df4",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9bd2cb527dcbd76977c18f3f6844638b6d5039f070accc41d064831f98aa7b40",
+    "zh:9df98266de85cf047c9a2e43b892c74479805e0936dbb3583aef314d2fa0f5fc",
+    "zh:a4fc8e9645b147902bcf36f10ea1891ca92661c4ee4135046cc79b8ce6fe1093",
+    "zh:afe3029760f7aa5484e26c80670f86b6b5054126776376ba6aec4aa8a41483ce",
+    "zh:c158cd1790422237ab2a2e10fc02e5522bd7bce39c067ffbc9edda1e6c9ebf3b",
+    "zh:f5408929d5df6f81fcb93a433e0dbc0432b748b400cc41910328b936a7590fd5",
+    "zh:f6331bb27134e288d8c324b2390c610fd924f71af1ec27f79070dfa26f4dd410",
+    "zh:f6b8b429d5fa71f186bda45468bbde230a1697a38480487f41d7172f1e374e2d",
+  ]
+}

--- a/modules/elb/alb/variables.tf
+++ b/modules/elb/alb/variables.tf
@@ -19,13 +19,7 @@ variable "listeners" {
 }
 
 variable "target_groups" {
-  type = map(object({
-    name_prefix = optional(string)
-    protocol    = string
-    port        = number
-    target_type = string
-    target_id = optional(string)
-  }))
+  type = map(any)
 }
 
 variable "env" {


### PR DESCRIPTION
## 관련 이슈
- close #48

## 작업 내용
- ELB Target Group 헬스 체크 적용

## 설명
- 타입 오류로 인해 ELB에 정상적으로 헬스 체크가 적용되지 않던 문제를 해결하는 PR입니다.
- 여담으로 기본값이 `HTTP GET /`이라서 Swagger는 헬스 체크를 통과하고 있었습니다.