### PR TITLE
CloudFront에 HTTPS 리다이렉트 정책을 추가한다.

### DIFF
--- a/global/static/cloudfront/terragrunt.hcl
+++ b/global/static/cloudfront/terragrunt.hcl
@@ -39,11 +39,11 @@ inputs = {
     }
   }
   origin_access_control = {
-    "static" : {
-      "description" : "Gotchai static resources",
-      "origin_type" : "s3",
-      "signing_behavior" : "always",
-      "signing_protocol" : "sigv4"
+    static = {
+      description      = "Gotchai static resources",
+      origin_type      = "s3",
+      signing_behavior = "always",
+      signing_protocol = "sigv4"
     }
   }
   default_cache_behavior = {

--- a/global/static/cloudfront/terragrunt.hcl
+++ b/global/static/cloudfront/terragrunt.hcl
@@ -48,10 +48,9 @@ inputs = {
   }
   default_cache_behavior = {
     target_origin_id       = "static_bucket"
-    viewer_protocol_policy = "allow-all"
+    viewer_protocol_policy = "redirect-to-https"
     cache_policy_name      = "Managed-CachingOptimized"
     use_forwarded_values = false
-
     allowed_methods = ["GET", "HEAD", "OPTIONS"]
     cached_methods  = ["GET", "HEAD"]
     compress        = true

--- a/global/static/cloudfront/terragrunt.hcl
+++ b/global/static/cloudfront/terragrunt.hcl
@@ -50,10 +50,10 @@ inputs = {
     target_origin_id       = "static_bucket"
     viewer_protocol_policy = "redirect-to-https"
     cache_policy_name      = "Managed-CachingOptimized"
-    use_forwarded_values = false
-    allowed_methods = ["GET", "HEAD", "OPTIONS"]
-    cached_methods  = ["GET", "HEAD"]
-    compress        = true
+    use_forwarded_values   = false
+    allowed_methods        = ["GET", "HEAD", "OPTIONS"]
+    cached_methods         = ["GET", "HEAD"]
+    compress               = true
   }
   certificate_arn = dependency.acm.outputs.arn
 }

--- a/global/web/cloudfront/terragrunt.hcl
+++ b/global/web/cloudfront/terragrunt.hcl
@@ -51,10 +51,10 @@ inputs = {
     target_origin_id       = "web_bucket"
     cache_policy_name      = "Managed-CachingOptimized"
     viewer_protocol_policy = "redirect-to-https"
-    use_forwarded_values = false
-    allowed_methods = ["GET", "HEAD", "OPTIONS"]
-    cached_methods  = ["GET", "HEAD"]
-    query_string    = true
+    use_forwarded_values   = false
+    allowed_methods        = ["GET", "HEAD", "OPTIONS"]
+    cached_methods         = ["GET", "HEAD"]
+    query_string           = true
   }
   custom_error_responses = [
     {

--- a/global/web/cloudfront/terragrunt.hcl
+++ b/global/web/cloudfront/terragrunt.hcl
@@ -39,11 +39,11 @@ inputs = {
     }
   }
   origin_access_control = {
-    "web" : {
-      "description" : "Gotchai web",
-      "origin_type" : "s3",
-      "signing_behavior" : "always",
-      "signing_protocol" : "sigv4"
+    web = {
+      description      = "Gotchai web",
+      origin_type      = "s3",
+      signing_behavior = "always",
+      signing_protocol = "sigv4"
     }
   }
   default_root_object = "index.html"

--- a/global/web/cloudfront/terragrunt.hcl
+++ b/global/web/cloudfront/terragrunt.hcl
@@ -49,11 +49,11 @@ inputs = {
   default_root_object = "index.html"
   default_cache_behavior = {
     target_origin_id       = "web_bucket"
-    viewer_protocol_policy = "allow-all"
-
+    cache_policy_name      = "Managed-CachingOptimized"
+    viewer_protocol_policy = "redirect-to-https"
+    use_forwarded_values = false
     allowed_methods = ["GET", "HEAD", "OPTIONS"]
     cached_methods  = ["GET", "HEAD"]
-    compress        = true
     query_string    = true
   }
   custom_error_responses = [


### PR DESCRIPTION
## 관련 이슈
- close #50

## 작업 내용
- CloudFront에 HTTPS로 리다이렉트되는 뷰어 프로토콜 정책 추가

## 설명
- 프론트 웹 배포에서 누락됐었던 캐시 정책도 추가했습니다.
